### PR TITLE
Fix Fitzpatrick name in response example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Search the medical database with text or image queries.
   "image_results": [
     {
       "score": 0.78,
-      "source": "Fitzpatricks Color Atlas",
+      "source": "Fitzpatrick's Color Atlas",
       "page": "15",
-      "original_id": "Fitzpatricks_Color_Atlas_page_15_image_1"
+      "original_id": "Fitzpatrick's_Color_Atlas_page_15_image_1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- correct the title for Fitzpatrick's Color Atlas in the README example
- update the example `original_id` to match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68405496c9808325ade412a943c01282